### PR TITLE
Initial implementation for Windows

### DIFF
--- a/doc/g.txt
+++ b/doc/g.txt
@@ -30,7 +30,7 @@ Table of Contents
 
 Vim-G is a tiny plugin that allows you to perform a quick Google search
 directly from Vim. It opens a new browser window with results. Vim-G uses Perl
-for url encoding.
+for URL encoding (except on Windows).
 
 ----------------------------------------------------------------------------
 2. Usage                                                             *g-usage*

--- a/plugin/g.vim
+++ b/plugin/g.vim
@@ -73,10 +73,11 @@ fun! s:goo(ft, ...)
 
   if has('win32')
     " Target command: start "" "<url>"
-    verbose execute "! " . g:vim_g_open_command . " \"\" \"" . g:vim_g_query_url  . query . "\""
+    silent! execute "! " . g:vim_g_open_command . " \"\" \"" . g:vim_g_query_url  . query . "\""
   else
-    silent! exe "! goo_query=\"$(" . g:vim_g_perl_command .
+    silent! execute "! goo_query=\"$(" . g:vim_g_perl_command .
       \" -MURI::Escape -e 'print uri_escape($ARGV[0]);' \"" . query . "\")\" && " .
-      \g:vim_g_open_command . ' "' . g:vim_g_query_url . "$goo_query" . '" > /dev/null 2>&1 &' | redraw!
+      \g:vim_g_open_command . ' "' . g:vim_g_query_url . "$goo_query" . '" > /dev/null 2>&1 &'
   endif
+  redraw!
 endfun

--- a/plugin/g.vim
+++ b/plugin/g.vim
@@ -23,7 +23,9 @@ endif
 let g:loaded_vim_g = 1
 
 if !exists("g:vim_g_open_command")
-  if substitute(system('uname'), "\n", "", "") == 'Darwin'
+  if has("win32")
+    let g:vim_g_open_command = "start"
+  elseif substitute(system('uname'), "\n", "", "") == 'Darwin'
     let g:vim_g_open_command = "open"
   else
     let g:vim_g_open_command = "xdg-open"
@@ -69,7 +71,12 @@ fun! s:goo(ft, ...)
   let query = substitute(join(words, " "), '^\s*\(.\{-}\)\s*$', '\1', '')
   let query = substitute(query, '"', '\\"', 'g')
 
-  silent! exe "! goo_query=\"$(" . g:vim_g_perl_command .
-    \" -MURI::Escape -e 'print uri_escape($ARGV[0]);' \"" . query . "\")\" && " .
-    \g:vim_g_open_command . ' "' . g:vim_g_query_url . "$goo_query" . '" > /dev/null 2>&1 &' | redraw!
+  if has('win32')
+    " Target command: start "" "<url>"
+    verbose execute "! " . g:vim_g_open_command . " \"\" \"" . g:vim_g_query_url  . query . "\""
+  else
+    silent! exe "! goo_query=\"$(" . g:vim_g_perl_command .
+      \" -MURI::Escape -e 'print uri_escape($ARGV[0]);' \"" . query . "\")\" && " .
+      \g:vim_g_open_command . ' "' . g:vim_g_query_url . "$goo_query" . '" > /dev/null 2>&1 &' | redraw!
+  endif
 endfun


### PR DESCRIPTION
Use the Windows `start` command to open URLs on Windows. Limitations: doesn't use the Perl fancy escaping trick. This fixes #5.
